### PR TITLE
Implement block confirmations

### DIFF
--- a/server/blockchain/event.go
+++ b/server/blockchain/event.go
@@ -56,3 +56,25 @@ type JSONEvent struct {
 	Event       *EventInformation       `json:"event"`
 	Transaction *TransactionInformation `json:"transaction"`
 }
+
+// Enum values for event_log_type
+const (
+	EventLogTypeCreate = "create"
+	EventLogTypeRemove = "remove"
+)
+
+// ReturnedEvent is an event struct sent through websocket.
+type ReturnedEvent struct {
+	LogID int    `json:"log_id,omitempty"`
+	Type  string `json:"type"` // "create" or "remove"
+	*JSONEvent
+}
+
+// IsEqual checks if two given events are the same event
+func (e *ReturnedEvent) IsEqual(other *ReturnedEvent) bool {
+	return e.Transaction.BlockNumber == other.Transaction.BlockNumber &&
+		e.Transaction.BlockHash == other.Transaction.BlockHash &&
+		e.Transaction.TXIndexInBlock == other.Transaction.TXIndexInBlock &&
+		e.Transaction.TXHash == other.Transaction.TXHash &&
+		e.Event.EventIndexInLog == other.Event.EventIndexInLog
+}

--- a/server/mbAPI/mbAPI.go
+++ b/server/mbAPI/mbAPI.go
@@ -41,3 +41,32 @@ func Post(endpoint string, apiKey string, payload interface{}) (*APICallResult, 
 	}
 	return &result, nil
 }
+
+// Get provides a wrapped function to call a Multibaas GET API
+func Get(endpoint string, apiKey string) (*APICallResult, error) {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result APICallResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/server/watcher/watcher.go
+++ b/server/watcher/watcher.go
@@ -227,7 +227,6 @@ func (w *Watcher) Watch() chan struct{} {
 					// we only handle the first event if "bc.Confirmations" blocks have been confirmed since the event
 					for len(events) > 0 && events[0].Transaction.BlockNumber+int64(bc.Confirmations) <= latestBlock {
 						e := events[0]
-						events = events[1:]
 						switch e.Event.Name {
 						case "Deposit":
 							if err := w.handleDepositEvent(&e); err != nil {
@@ -249,6 +248,9 @@ func (w *Watcher) Watch() chan struct{} {
 								}
 							}
 						}
+
+						// if the first event is successfully processed, remove it from the list
+						events = events[1:]
 					}
 
 				sleep:

--- a/server/watcher/watcher.go
+++ b/server/watcher/watcher.go
@@ -3,12 +3,16 @@
 package watcher
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/curvegrid/looking-glass/server/blockchain"
 	"github.com/curvegrid/looking-glass/server/bridge"
+	"github.com/curvegrid/looking-glass/server/customError"
+	"github.com/curvegrid/looking-glass/server/mbAPI"
 	"github.com/gorilla/websocket"
 	logger "github.com/sirupsen/logrus"
 )
@@ -35,7 +39,7 @@ func (w *Watcher) getEventStreamURL(bc *blockchain.Blockchain) *url.URL {
 
 // handleDepositEvent reads a Deposit event. It then uses HSM auto-signing to
 // vote/execute the (cross-chain) deposit proposal associated with the read event.
-func (w *Watcher) handleDepositEvent(e *blockchain.JSONEvent) error {
+func (w *Watcher) handleDepositEvent(e *blockchain.ReturnedEvent) error {
 	destinationChainID, err := strconv.Atoi(fmt.Sprint(e.Event.Inputs[0].Value))
 	if err != nil {
 		return err
@@ -58,7 +62,7 @@ func (w *Watcher) handleDepositEvent(e *blockchain.JSONEvent) error {
 		return err
 	}
 	d.OriginChainID = w.ChainID
-	logger.Infof("Got a Deposit event from chain %d: %+v", w.ChainID, *d)
+	logger.Infof("Handle a Deposit event from chain %d: %+v", w.ChainID, *d)
 
 	err = bridge.VoteProposal(d)
 	if err != nil {
@@ -68,7 +72,25 @@ func (w *Watcher) handleDepositEvent(e *blockchain.JSONEvent) error {
 	return nil
 }
 
-func (w *Watcher) parseProposalFromEvent(e *blockchain.JSONEvent) (*bridge.Proposal, error) {
+func getLatestBlockNumber(bc *blockchain.Blockchain) (int64, error) {
+	endpoint := fmt.Sprintf("http://%s/api/v0/chains/ethereum/status", bc.MbEndpoint)
+	result, err := mbAPI.Get(endpoint, bc.BearerToken)
+	if err != nil {
+		return 0, err
+	}
+	if result.Status != 200 {
+		return 0, customError.NewAPICallError(endpoint, result.Status, result.Message)
+	}
+	var data struct {
+		BlockNumber int64 `json:"blockNumber"`
+	}
+	if err := json.Unmarshal(result.Result, &data); err != nil {
+		return 0, err
+	}
+	return data.BlockNumber, nil
+}
+
+func (w *Watcher) parseProposalFromEvent(e *blockchain.ReturnedEvent) (*bridge.Proposal, error) {
 	var p bridge.Proposal
 	var err error
 
@@ -93,13 +115,13 @@ func (w *Watcher) parseProposalFromEvent(e *blockchain.JSONEvent) (*bridge.Propo
 
 // handleProposalEvent reads a ProposalEvent. Depends on the proposal's status, the
 // watcher then uses HSM to execute the proposal.
-func (w *Watcher) handleProposalEvent(e *blockchain.JSONEvent) error {
+func (w *Watcher) handleProposalEvent(e *blockchain.ReturnedEvent) error {
 	p, err := w.parseProposalFromEvent(e)
 	if err != nil {
 		return err
 	}
 
-	logger.Infof("Got ProposalEvent event from chain %d with proposal %+v", w.ChainID, *p)
+	logger.Infof("Handle ProposalEvent event from chain %d with proposal %+v", w.ChainID, *p)
 	if p.Status != 2 {
 		return nil
 	}
@@ -122,12 +144,12 @@ func (w *Watcher) handleProposalEvent(e *blockchain.JSONEvent) error {
 	return nil
 }
 
-func (w *Watcher) handleProposalVote(e *blockchain.JSONEvent) error {
+func (w *Watcher) handleProposalVote(e *blockchain.ReturnedEvent) error {
 	p, err := w.parseProposalFromEvent(e)
 	if err != nil {
 		return err
 	}
-	logger.Infof("Got ProposalVote event from chain %d with proposal %+v", w.ChainID, *p)
+	logger.Infof("Handle ProposalVote event from chain %d with proposal %+v", w.ChainID, *p)
 	return nil
 }
 
@@ -144,35 +166,89 @@ func (w *Watcher) Watch() chan struct{} {
 
 	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		logger.Fatalf("Cannot connect to websocket dial:", err.Error())
+		logger.Fatalf("Cannot connect to websocket dial: %s", err.Error())
 	}
 
 	done := make(chan struct{})
 	go func() {
+		/*
+		   To implement block confirmations for the watcher,
+		   we store a list of events received from the monitor.
+		   We only handle an event of a given block if after that
+		   block, a specific number of blocks has been confirmed.
+		*/
+
 		defer close(done)
-		for {
-			var e blockchain.JSONEvent
-			c.ReadJSON(&e)
-			if err != nil {
-				logger.Errorf("Cannot read websocket message:", err.Error())
-				continue
+
+		eventCh := make(chan blockchain.ReturnedEvent)
+
+		// read events from websocket and pass them to event Channel
+		go func() {
+			for {
+				var e blockchain.ReturnedEvent
+				c.ReadJSON(&e)
+				if err != nil {
+					logger.Errorf("Cannot read websocket message: %s", err.Error())
+					continue
+				}
+
+				eventCh <- e
+				logger.Printf("Got event %s (type: %s) from chain %d (block %d)",
+					e.Event.Name, e.Type, w.ChainID, e.Transaction.BlockNumber)
 			}
-			switch e.Event.Name {
-			case "Deposit":
-				if err := w.handleDepositEvent(&e); err != nil {
-					logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
-				}
-			case "ProposalEvent":
+		}()
+
+		var events []blockchain.ReturnedEvent
+		for {
+			select {
+			case e := <-eventCh:
 				{
-					if err := w.handleProposalEvent(&e); err != nil {
-						logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+					if e.Type == blockchain.EventLogTypeCreate {
+						events = append(events, e)
+					} else { // = EventLogTypeRemove
+						// if the event received from the monitor is deleted from the blockchain,
+						// we remove it from the list of events we need to consider.
+						for i, v := range events {
+							if v.IsEqual(&e) {
+								events = append(events[:i], events[i+1:]...)
+								break
+							}
+						}
 					}
 				}
-			case "ProposalVote":
+			default:
 				{
-					if err := w.handleProposalVote(&e); err != nil {
-						logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+					latestBlock, err := getLatestBlockNumber(bc)
+					if err != nil {
+						logger.Errorf("Cannot retrieve the latest block of chain %d: %s", w.ChainID, err.Error())
+						continue
 					}
+
+					// we only handle the first event if "bc.Confirmations" blocks have been confirmed since the event
+					for len(events) > 0 && events[0].Transaction.BlockNumber+int64(bc.Confirmations) <= latestBlock {
+						e := events[0]
+						events = events[1:]
+						switch e.Event.Name {
+						case "Deposit":
+							if err := w.handleDepositEvent(&e); err != nil {
+								logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+							}
+						case "ProposalEvent":
+							{
+								if err := w.handleProposalEvent(&e); err != nil {
+									logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+								}
+							}
+						case "ProposalVote":
+							{
+								if err := w.handleProposalVote(&e); err != nil {
+									logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+								}
+							}
+						}
+					}
+
+					time.Sleep(5 * time.Second)
 				}
 			}
 		}

--- a/server/watcher/watcher.go
+++ b/server/watcher/watcher.go
@@ -221,7 +221,7 @@ func (w *Watcher) Watch() chan struct{} {
 					latestBlock, err := getLatestBlockNumber(bc)
 					if err != nil {
 						logger.Errorf("Cannot retrieve the latest block of chain %d: %s", w.ChainID, err.Error())
-						continue
+						goto sleep
 					}
 
 					// we only handle the first event if "bc.Confirmations" blocks have been confirmed since the event
@@ -232,22 +232,26 @@ func (w *Watcher) Watch() chan struct{} {
 						case "Deposit":
 							if err := w.handleDepositEvent(&e); err != nil {
 								logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+								goto sleep
 							}
 						case "ProposalEvent":
 							{
 								if err := w.handleProposalEvent(&e); err != nil {
 									logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+									goto sleep
 								}
 							}
 						case "ProposalVote":
 							{
 								if err := w.handleProposalVote(&e); err != nil {
 									logger.Errorf("Cannot handle event %s: %s", e.Event.Name, err.Error())
+									goto sleep
 								}
 							}
 						}
 					}
 
+				sleep:
 					time.Sleep(5 * time.Second)
 				}
 			}


### PR DESCRIPTION
- add an event channel receiving events from monitor's websocket.
- implement logic to query the latest block number of a chain and wait to handle an event received from the event channel.